### PR TITLE
Implement provider-based SMS notification architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ Send an SMS notification:
 ```bash
 curl -X POST http://localhost:8080/notify/sms \
      -H 'Content-Type: application/json' \
-     -d '{"to":"+15555550123","message":"Hi"}'
+     -d '{"to":"+15555550123","message":"Hi","subscription":"kaleyra"}'
 ```

--- a/src/main/java/com/example/notificationservice/controller/NotificationController.java
+++ b/src/main/java/com/example/notificationservice/controller/NotificationController.java
@@ -1,5 +1,6 @@
 package com.example.notificationservice.controller;
 
+import com.example.notificationservice.provider.SmsSubscription;
 import com.example.notificationservice.service.NotificationService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -27,7 +28,9 @@ public class NotificationController {
     public ResponseEntity<String> sendSms(@RequestBody Map<String, String> payload) {
         String to = payload.get("to");
         String message = payload.get("message");
-        notificationService.sendSms(to, message);
+        String subscriptionValue = payload.get("subscription");
+        SmsSubscription subscription = SmsSubscription.valueOf(subscriptionValue.toUpperCase());
+        notificationService.sendSms(subscription, to, message);
         return ResponseEntity.ok("SMS sent");
     }
 }

--- a/src/main/java/com/example/notificationservice/provider/KaleyraSmsProvider.java
+++ b/src/main/java/com/example/notificationservice/provider/KaleyraSmsProvider.java
@@ -1,0 +1,14 @@
+package com.example.notificationservice.provider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KaleyraSmsProvider implements NotificationProvider {
+    private static final Logger logger = LoggerFactory.getLogger(KaleyraSmsProvider.class);
+
+    @Override
+    public void send(String to, String message) {
+        // Placeholder for integration with Kaleyra APIs
+        logger.info("[Kaleyra] Sending SMS to {} with message: {}", to, message);
+    }
+}

--- a/src/main/java/com/example/notificationservice/provider/NotificationProvider.java
+++ b/src/main/java/com/example/notificationservice/provider/NotificationProvider.java
@@ -1,0 +1,5 @@
+package com.example.notificationservice.provider;
+
+public interface NotificationProvider {
+    void send(String to, String message);
+}

--- a/src/main/java/com/example/notificationservice/provider/NotificationProviderFactory.java
+++ b/src/main/java/com/example/notificationservice/provider/NotificationProviderFactory.java
@@ -1,0 +1,16 @@
+package com.example.notificationservice.provider;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificationProviderFactory {
+    public NotificationProvider getProvider(NotificationType type, SmsSubscription subscription) {
+        if (type == NotificationType.SMS) {
+            return switch (subscription) {
+                case KALEYRA -> new KaleyraSmsProvider();
+                case VALUEFIRST -> new ValueFirstSmsProvider();
+            };
+        }
+        throw new IllegalArgumentException("Unsupported notification type: " + type);
+    }
+}

--- a/src/main/java/com/example/notificationservice/provider/NotificationType.java
+++ b/src/main/java/com/example/notificationservice/provider/NotificationType.java
@@ -1,0 +1,6 @@
+package com.example.notificationservice.provider;
+
+public enum NotificationType {
+    SMS,
+    EMAIL
+}

--- a/src/main/java/com/example/notificationservice/provider/SmsSubscription.java
+++ b/src/main/java/com/example/notificationservice/provider/SmsSubscription.java
@@ -1,0 +1,6 @@
+package com.example.notificationservice.provider;
+
+public enum SmsSubscription {
+    KALEYRA,
+    VALUEFIRST
+}

--- a/src/main/java/com/example/notificationservice/provider/ValueFirstSmsProvider.java
+++ b/src/main/java/com/example/notificationservice/provider/ValueFirstSmsProvider.java
@@ -1,0 +1,14 @@
+package com.example.notificationservice.provider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ValueFirstSmsProvider implements NotificationProvider {
+    private static final Logger logger = LoggerFactory.getLogger(ValueFirstSmsProvider.class);
+
+    @Override
+    public void send(String to, String message) {
+        // Placeholder for integration with ValueFirst APIs
+        logger.info("[ValueFirst] Sending SMS to {} with message: {}", to, message);
+    }
+}

--- a/src/main/java/com/example/notificationservice/service/NotificationService.java
+++ b/src/main/java/com/example/notificationservice/service/NotificationService.java
@@ -4,17 +4,29 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.example.notificationservice.provider.NotificationProvider;
+import com.example.notificationservice.provider.NotificationProviderFactory;
+import com.example.notificationservice.provider.NotificationType;
+import com.example.notificationservice.provider.SmsSubscription;
+
 @Service
 public class NotificationService {
     private static final Logger logger = LoggerFactory.getLogger(NotificationService.class);
+
+    private final NotificationProviderFactory providerFactory;
+
+    public NotificationService(NotificationProviderFactory providerFactory) {
+        this.providerFactory = providerFactory;
+    }
 
     public void sendEmail(String to, String message) {
         // Placeholder implementation
         logger.info("Sending email to {} with message: {}", to, message);
     }
 
-    public void sendSms(String to, String message) {
-        // Placeholder implementation
-        logger.info("Sending SMS to {} with message: {}", to, message);
+    public void sendSms(SmsSubscription subscription, String to, String message) {
+        NotificationProvider provider =
+                providerFactory.getProvider(NotificationType.SMS, subscription);
+        provider.send(to, message);
     }
 }


### PR DESCRIPTION
## Summary
- introduce `NotificationProvider` hierarchy for SMS notifications
- create `NotificationProviderFactory` to select provider based on type and subscription
- update `NotificationService` and controller to use the provider factory
- document new `subscription` field in README

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM because Maven Central is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684927194ae88330b907354c2a90323e