### PR TITLE
Refactor into hexagonal architecture

### DIFF
--- a/src/main/java/com/example/notificationservice/adapters/in/web/NotificationController.java
+++ b/src/main/java/com/example/notificationservice/adapters/in/web/NotificationController.java
@@ -1,26 +1,25 @@
-package com.example.notificationservice.controller;
+package com.example.notificationservice.adapters.in.web;
 
-import com.example.notificationservice.provider.SmsSubscription;
-import com.example.notificationservice.service.NotificationService;
+import com.example.notificationservice.domain.SmsSubscription;
+import com.example.notificationservice.application.port.in.NotificationUseCase;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
-
 @RestController
 @RequestMapping("/notify")
 public class NotificationController {
-    private final NotificationService notificationService;
+    private final NotificationUseCase notificationUseCase;
 
-    public NotificationController(NotificationService notificationService) {
-        this.notificationService = notificationService;
+    public NotificationController(NotificationUseCase notificationUseCase) {
+        this.notificationUseCase = notificationUseCase;
     }
 
     @PostMapping("/email")
     public ResponseEntity<String> sendEmail(@RequestBody Map<String, String> payload) {
         String to = payload.get("to");
         String message = payload.get("message");
-        notificationService.sendEmail(to, message);
+        notificationUseCase.sendEmail(to, message);
         return ResponseEntity.ok("Email sent");
     }
 
@@ -30,7 +29,7 @@ public class NotificationController {
         String message = payload.get("message");
         String subscriptionValue = payload.get("subscription");
         SmsSubscription subscription = SmsSubscription.valueOf(subscriptionValue.toUpperCase());
-        notificationService.sendSms(subscription, to, message);
+        notificationUseCase.sendSms(subscription, to, message);
         return ResponseEntity.ok("SMS sent");
     }
 }

--- a/src/main/java/com/example/notificationservice/adapters/out/sms/DefaultNotificationProviderFactory.java
+++ b/src/main/java/com/example/notificationservice/adapters/out/sms/DefaultNotificationProviderFactory.java
@@ -1,9 +1,15 @@
-package com.example.notificationservice.provider;
+package com.example.notificationservice.adapters.out.sms;
 
 import org.springframework.stereotype.Component;
 
+import com.example.notificationservice.application.port.out.NotificationProvider;
+import com.example.notificationservice.application.port.out.NotificationProviderFactory;
+import com.example.notificationservice.domain.NotificationType;
+import com.example.notificationservice.domain.SmsSubscription;
+
 @Component
-public class NotificationProviderFactory {
+public class DefaultNotificationProviderFactory implements NotificationProviderFactory {
+    @Override
     public NotificationProvider getProvider(NotificationType type, SmsSubscription subscription) {
         if (type == NotificationType.SMS) {
             return switch (subscription) {

--- a/src/main/java/com/example/notificationservice/adapters/out/sms/KaleyraSmsProvider.java
+++ b/src/main/java/com/example/notificationservice/adapters/out/sms/KaleyraSmsProvider.java
@@ -1,7 +1,8 @@
-package com.example.notificationservice.provider;
+package com.example.notificationservice.adapters.out.sms;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.example.notificationservice.application.port.out.NotificationProvider;
 
 public class KaleyraSmsProvider implements NotificationProvider {
     private static final Logger logger = LoggerFactory.getLogger(KaleyraSmsProvider.class);

--- a/src/main/java/com/example/notificationservice/adapters/out/sms/ValueFirstSmsProvider.java
+++ b/src/main/java/com/example/notificationservice/adapters/out/sms/ValueFirstSmsProvider.java
@@ -1,7 +1,8 @@
-package com.example.notificationservice.provider;
+package com.example.notificationservice.adapters.out.sms;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.example.notificationservice.application.port.out.NotificationProvider;
 
 public class ValueFirstSmsProvider implements NotificationProvider {
     private static final Logger logger = LoggerFactory.getLogger(ValueFirstSmsProvider.class);

--- a/src/main/java/com/example/notificationservice/application/port/in/NotificationUseCase.java
+++ b/src/main/java/com/example/notificationservice/application/port/in/NotificationUseCase.java
@@ -1,0 +1,9 @@
+package com.example.notificationservice.application.port.in;
+
+import com.example.notificationservice.domain.SmsSubscription;
+
+public interface NotificationUseCase {
+    void sendEmail(String to, String message);
+
+    void sendSms(SmsSubscription subscription, String to, String message);
+}

--- a/src/main/java/com/example/notificationservice/application/port/out/NotificationProvider.java
+++ b/src/main/java/com/example/notificationservice/application/port/out/NotificationProvider.java
@@ -1,4 +1,4 @@
-package com.example.notificationservice.provider;
+package com.example.notificationservice.application.port.out;
 
 public interface NotificationProvider {
     void send(String to, String message);

--- a/src/main/java/com/example/notificationservice/application/port/out/NotificationProviderFactory.java
+++ b/src/main/java/com/example/notificationservice/application/port/out/NotificationProviderFactory.java
@@ -1,0 +1,8 @@
+package com.example.notificationservice.application.port.out;
+
+import com.example.notificationservice.domain.NotificationType;
+import com.example.notificationservice.domain.SmsSubscription;
+
+public interface NotificationProviderFactory {
+    NotificationProvider getProvider(NotificationType type, SmsSubscription subscription);
+}

--- a/src/main/java/com/example/notificationservice/application/service/NotificationService.java
+++ b/src/main/java/com/example/notificationservice/application/service/NotificationService.java
@@ -1,16 +1,17 @@
-package com.example.notificationservice.service;
+package com.example.notificationservice.application.service;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import com.example.notificationservice.provider.NotificationProvider;
-import com.example.notificationservice.provider.NotificationProviderFactory;
-import com.example.notificationservice.provider.NotificationType;
-import com.example.notificationservice.provider.SmsSubscription;
+import com.example.notificationservice.application.port.out.NotificationProvider;
+import com.example.notificationservice.application.port.in.NotificationUseCase;
+import com.example.notificationservice.application.port.out.NotificationProviderFactory;
+import com.example.notificationservice.domain.NotificationType;
+import com.example.notificationservice.domain.SmsSubscription;
 
 @Service
-public class NotificationService {
+public class NotificationService implements NotificationUseCase {
     private static final Logger logger = LoggerFactory.getLogger(NotificationService.class);
 
     private final NotificationProviderFactory providerFactory;

--- a/src/main/java/com/example/notificationservice/domain/NotificationType.java
+++ b/src/main/java/com/example/notificationservice/domain/NotificationType.java
@@ -1,4 +1,4 @@
-package com.example.notificationservice.provider;
+package com.example.notificationservice.domain;
 
 public enum NotificationType {
     SMS,

--- a/src/main/java/com/example/notificationservice/domain/SmsSubscription.java
+++ b/src/main/java/com/example/notificationservice/domain/SmsSubscription.java
@@ -1,4 +1,4 @@
-package com.example.notificationservice.provider;
+package com.example.notificationservice.domain;
 
 public enum SmsSubscription {
     KALEYRA,


### PR DESCRIPTION
## Summary
- move controller to `adapters.in.web`
- add ports and services implementing hexagonal structure
- move provider implementations to `adapters.out.sms`
- move enums into `domain`

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6849282a82c08330a4987c958772b1fc